### PR TITLE
just use relative "root" for url pos

### DIFF
--- a/_includes/in-org-head.html
+++ b/_includes/in-org-head.html
@@ -1,4 +1,4 @@
 <meta name="viewport" content="width=device-width">
 <meta name="viewport" content="user-scalable=yes">
 
-<link rel="stylesheet" href="{{ site.url }}/assets/css/org.css">
+<link rel="stylesheet" href="/assets/css/org.css">


### PR DESCRIPTION
This fixes loading under HTTPS pages. GH Pages seems to keep giving the HTTP URL.
